### PR TITLE
refactor: bump packages and gnome runtime to 47

### DIFF
--- a/modules/gtkmm-3.0.yaml
+++ b/modules/gtkmm-3.0.yaml
@@ -61,8 +61,8 @@ modules:
       - -Dbuild-examples=false
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.7.tar.xz
-        sha256: fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3
+        url: https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.8.tar.xz
+        sha256: 64f11d3b95a24e2a8d4166ecff518730f79ecc27222ef41faf7c7e0340fc9329
         x-checker-data:
           type: anitya
           project-id: 369440

--- a/modules/imagemagick.yml
+++ b/modules/imagemagick.yml
@@ -7,8 +7,8 @@ config-opts:
   - --with-threads
 sources:
   - type: archive
-    url: https://github.com/ImageMagick/ImageMagick/archive/7.1.1-39.tar.gz
-    sha256: b2eb652d9221bdeb65772503891d8bfcfc36b3b1a2c9bb35b9d247a08965fd5d
+    url: https://github.com/ImageMagick/ImageMagick/archive/7.1.1-47.tar.gz
+    sha256: 818e21a248986f15a6ba0221ab3ccbaed3d3abee4a6feb4609c6f2432a30d7ed
     x-checker-data:
       type: anitya
       project-id: 1372

--- a/modules/python3-lxml.yaml
+++ b/modules/python3-lxml.yaml
@@ -2,11 +2,12 @@
 name: python3-lxml
 buildsystem: simple
 build-commands:
-  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "lxml==5.3.0" --ignore-installed --no-build-isolation
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "lxml==5.3.0" --ignore-installed --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz
-    sha256: 4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f
+    url: https://files.pythonhosted.org/packages/80/61/d3dc048cd6c7be6fe45b80cedcbdd4326ba4d550375f266d9f4246d0f4bc/lxml-5.3.2.tar.gz
+    sha256: 773947d0ed809ddad824b7b14467e1a481b8976e87278ac4a730c2f7c7fcddc1
     x-checker-data:
       name: lxml
       type: pypi

--- a/modules/python3-lxml.yaml
+++ b/modules/python3-lxml.yaml
@@ -6,8 +6,8 @@ build-commands:
     --prefix=${FLATPAK_DEST} "lxml==5.3.0" --ignore-installed --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/80/61/d3dc048cd6c7be6fe45b80cedcbdd4326ba4d550375f266d9f4246d0f4bc/lxml-5.3.2.tar.gz
-    sha256: 773947d0ed809ddad824b7b14467e1a481b8976e87278ac4a730c2f7c7fcddc1
+    url: https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz
+    sha256: 4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f
     x-checker-data:
       name: lxml
       type: pypi

--- a/org.synfig.SynfigStudio.yaml
+++ b/org.synfig.SynfigStudio.yaml
@@ -1,7 +1,7 @@
 app-id: org.synfig.SynfigStudio
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: "46"
+runtime-version: "47"
 sdk: org.gnome.Sdk
 command: synfigstudio
 rename-icon: synfig_icon

--- a/org.synfig.SynfigStudio.yaml
+++ b/org.synfig.SynfigStudio.yaml
@@ -1,7 +1,7 @@
 app-id: org.synfig.SynfigStudio
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: synfigstudio
 rename-icon: synfig_icon
@@ -18,8 +18,8 @@ cleanup:
   - /lib/pkgconfig
   - /share/aclocal
   - /share/man
-  - "*.la"
-  - "*.a"
+  - '*.la'
+  - '*.a'
 
 modules:
   - shared-modules/intltool/intltool-0.51.json
@@ -94,8 +94,8 @@ modules:
       - /share/ffmpeg/examples
     sources:
       - type: archive
-        url: https://ffmpeg.org/releases/ffmpeg-6.1.1.tar.xz
-        sha256: 8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968
+        url: https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz
+        sha256: 733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
         x-checker-data:
           type: anitya
           project-id: 5405


### PR DESCRIPTION
This PR bumps the GNOME runtime version to 47. Fixes #49.

This is my first contribution, so please let me know if I am missing/forgetting anything.