### PR TITLE
refactor: bump packages and gnome runtime to 48

### DIFF
--- a/org.synfig.SynfigStudio.yaml
+++ b/org.synfig.SynfigStudio.yaml
@@ -1,7 +1,7 @@
 app-id: org.synfig.SynfigStudio
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: synfigstudio
 rename-icon: synfig_icon


### PR DESCRIPTION
This PR bumps the GNOME runtime version to 48. I will add package updates later if needed.