### PR TITLE
Update the GNOME runtime to 49

### DIFF
--- a/org.synfig.SynfigStudio.yaml
+++ b/org.synfig.SynfigStudio.yaml
@@ -1,7 +1,7 @@
 app-id: org.synfig.SynfigStudio
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: synfigstudio
 rename-icon: synfig_icon


### PR DESCRIPTION
This PR updates the GNOME runtime to 49.