### PR TITLE
Disable Flathub External Data Checker (f-e-d-c)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "disable-external-data-checker": true
+}


### PR DESCRIPTION
Flathubbot has been creating too much PR mostly without any success.

I think it would be good to close automatic PR creation until the data-checker optimizations are complete.

See: https://github.com/flathub/org.synfig.SynfigStudio/pulls?q=is%3Apr+author%3Aflathubbot+is%3Aclosed