### PR TITLE
Remove mm-common

### DIFF
--- a/modules/gtkmm-3.0.yaml
+++ b/modules/gtkmm-3.0.yaml
@@ -13,22 +13,9 @@ sources:
       project-id: 311572
       url-template: https://download.gnome.org/sources/gtkmm/$major.$minor/gtkmm-$version.tar.xz
 modules:
-  - name: mm-common
-    buildsystem: meson
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz
-        sha256: b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7
-        x-checker-data:
-          type: anitya
-          project-id: 13152
-          url-template: https://download.gnome.org/sources/mm-common/$major.$minor/mm-common-$version.tar.xz
-    cleanup:
-      - '*'
 
   - name: sigc++-2
-    config-opts:
-      - --disable-documentation
+    buildsystem: meson
     sources:
       - type: archive
         url: https://download.gnome.org/sources/libsigc++/2.12/libsigc++-2.12.1.tar.xz
@@ -39,8 +26,7 @@ modules:
           url-template: https://download.gnome.org/sources/libsigc++/$major.$minor/libsigc++-$version.tar.xz
 
   - name: cairomm
-    config-opts:
-      - --disable-documentation
+    buildsystem: meson
     cleanup:
       - /lib/cairomm-1.0
     sources:

--- a/org.synfig.SynfigStudio.yaml
+++ b/org.synfig.SynfigStudio.yaml
@@ -6,7 +6,7 @@ sdk: org.gnome.Sdk
 command: synfigstudio
 rename-icon: synfig_icon
 finish-args:
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=ipc
   - --socket=wayland
   - --socket=pulseaudio


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80